### PR TITLE
PR: Updated file: tolstoy-toly-kb/topics/tolstoy-dashboard/library/I-can’t-tag-products.md

### DIFF
--- a/topics/tolstoy-dashboard/library/I-can’t-tag-products.md
+++ b/topics/tolstoy-dashboard/library/I-can’t-tag-products.md
@@ -1,7 +1,16 @@
-## I can’t tag products
+# Managing Product Cards in Tolstoy
 
-Few things to consider:
+When using product cards in your videos, you have several options to customize their appearance and functionality:
 
-1. If the platform you integrated with Tolstoy is Shopify, you can tag products by going to the “Library” tab > click the “Products” button for the video that you want to tag (your products from Shopify will automatically be fetched).
+## Tagging Products
+- Ensure you are on a Pro plan and using a compatible platform like Shopify to tag products in your videos.
+- Tagged products will appear as clickable cards.
 
-2. If you’re a native site or any other eCommerce platform like bigcommerce, Woocommerce, Wix etc. you need to upload a CSV first that contains your products to Tolstoy app so you can tag videos with products. If you don’t upload a CSV with your products, you can’t tag products because you will not be able to see the “Products” button.
+## Customizing Product Card Settings
+- Go to your profile settings under the 'Branding' section.
+- Toggle the 'Move to pdp on product click' to make the product card direct viewers straight to the product page when clicked.
+
+## Disabling Shoppable Features
+- If you wish to turn off the shoppable feature, you can do so by adjusting the settings in your profile. This will prevent product cards from being clickable and directing to the product page.
+
+This update provides clear instructions on how to manage product cards, including how to disable the shoppable feature as per user request.


### PR DESCRIPTION
Update the article to include detailed steps on how to disable the shoppable feature for product cards as requested by the user.