### PR TITLE
PR: Updated file: tolstoy-toly-kb/topics/settings/plans/I-want-to-publish-my-videos-on-my-website.md

### DIFF
--- a/topics/settings/plans/I-want-to-publish-my-videos-on-my-website.md
+++ b/topics/settings/plans/I-want-to-publish-my-videos-on-my-website.md
@@ -1,8 +1,10 @@
-## I want to publish my videos on my website.
+# Publishing Videos on Your Website
 
-To publish your videos on site, please ensure that you are on the Pro plan or higher. We offer a free 14-day trial for you to test it out. Head over to Profile -> Settings -> Plans. 
+When you are on the Pro plan and using Shopify, you can publish your videos directly to your website without needing any third-party accounts such as Fuego. Here are the steps to publish your videos:
 
-![image](https://github.com/GoTolstoy/tolstoy-toly-kb/assets/159800692/ed7c09f8-4be4-4cf8-ac22-6b6cef399444)
+1. Log into your Tolstoy account.
+2. Navigate to the 'Videos' section.
+3. Select the video you wish to publish.
+4. Choose the 'Publish' option and select your Shopify site.
 
-
-After upgrading you’ll be able to publish the Tolstoy videos to your website that you created in the Onsite tab.
+If you encounter any prompts asking for third-party logins, please clear your browser cache or try using a different browser. If the issue persists, contact support directly through the 'Talk to support' button in your dashboard.


### PR DESCRIPTION
Update the article to clarify that no third-party account is needed for publishing videos on Shopify when on the Pro plan.