### PR TITLE
PR: Created article: Displaying Videos on PDP Pages in Tapcart App

### DIFF
--- a/topics/knowledge-manager-articles/displaying-videos-on-pdp-pages-in-tapcart-app.md
+++ b/topics/knowledge-manager-articles/displaying-videos-on-pdp-pages-in-tapcart-app.md
@@ -1,0 +1,17 @@
+# Displaying Videos on PDP Pages in Tapcart App
+
+When using the Tapcart app on Shopify, especially under the Free plan, users may encounter issues with displaying videos on their product detail pages (PDP). This article provides a detailed explanation, troubleshooting steps, integration checks, and upgrade options.
+
+## Why Videos May Not Show on PDP Pages
+- **Plan Limitations**: Users on the Free plan are restricted to publishing videos offsite (e.g., through email or SMS) and cannot display videos directly on PDP pages.
+- **Integration Issues**: Ensure that the integration between Tapcart and Tolstoy is correctly set up and functioning.
+
+## Troubleshooting Steps
+1. **Video Setup**: Confirm that videos are correctly set up in the Tolstoy Dashboard and tagged to the products.
+2. **Integration Check**: Verify the integration status between Tapcart and Tolstoy.
+3. **App Sync**: Check if there are any syncing issues and ensure that the latest changes are updated in the Tapcart app.
+
+## Upgrade Options
+To enable video display on PDP pages, consider upgrading to the Pro plan or higher, which offers enhanced features including direct video publishing on websites.
+
+For further assistance, contact our support team.


### PR DESCRIPTION
Create a new article to address the specific issue of videos not showing on PDP pages within the Tapcart app for users on the Free plan using Shopify. This article includes troubleshooting steps, integration checks, and upgrade options, filling a gap in the current knowledge base and providing clear guidance to users facing this issue.