### PR TITLE
PR: Created article: Adding a Carousel to a Specific Product Page on Shopify

### DIFF
--- a/topics/knowledge-manager-articles/adding-a-carousel-to-a-specific-product-page-on-shopify.md
+++ b/topics/knowledge-manager-articles/adding-a-carousel-to-a-specific-product-page-on-shopify.md
@@ -1,0 +1,21 @@
+# Adding a Carousel to a Specific Product Page on Shopify
+
+This guide provides detailed instructions on how to add a carousel to a specific product page on Shopify, specifically for users on the Free plan.
+
+## Step-by-Step Instructions
+1. **Create the Carousel**: Navigate to the Onsite section in your Tolstoy dashboard and select the Carousel layout.
+2. **Publish the Carousel**: After setting up your carousel, click on the 'Publish' button and copy the Publish ID.
+3. **Customize Your Shopify Theme**: Access your Shopify admin panel, go to 'Online Store', and then click on 'Customize'.
+4. **Add the Carousel to a Product Page**:
+   - Navigate to the specific product page where you want the Carousel to appear.
+   - Choose 'Add section' or 'Add block' depending on your theme's layout.
+   - Search for 'Tolstoy Carousel' and select it.
+   - Paste the Publish ID into the designated field.
+   - Save your changes.
+
+## Troubleshooting Tips
+- Ensure that your theme supports sections or blocks.
+- Verify that the Publish ID is correctly pasted.
+- If the carousel does not appear, clear your cache and try again.
+
+By following these steps, you can successfully add a carousel to a specific product page on Shopify using the Free plan.


### PR DESCRIPTION
Create a new article to provide specific, detailed instructions on adding a carousel to a specific product page on Shopify for users on the Free plan. This addresses the gap identified in the conversation where the user needed more tailored information.