### PR TITLE
PR: Created article: Videos Not Reflecting in Shopify Collections

### DIFF
--- a/topics/knowledge-manager-articles/videos-not-reflecting-in-shopify-collections.md
+++ b/topics/knowledge-manager-articles/videos-not-reflecting-in-shopify-collections.md
@@ -1,0 +1,25 @@
+# Videos Not Reflecting in Shopify Collections
+
+If you're experiencing issues with videos not appearing in your Shopify collections despite proper setup, follow these troubleshooting steps to resolve the issue:
+
+## 1. Verify Video Creation in Tolstoy Dashboard
+- Ensure that the video was created in the 'Onsite' tab and is designated for collections.
+
+## 2. Add Tolstoy App Block to Shopify Theme
+- In your Shopify admin, navigate to Themes > Customize.
+- Go to your collections page template and add the Tolstoy app block or stories.
+- Paste the ID of the Tolstoy video you created.
+
+## 3. Enable Tolstoy in Theme Settings
+- Still in the theme customization area, make sure the Tolstoy app embed is toggled on.
+
+## 4. Check for Theme Compatibility
+- Some themes may have specific restrictions or configurations that prevent external apps from displaying content correctly. Consult the theme's documentation or support for guidance.
+
+## 5. Clear Cache and Cookies
+- Sometimes, browser or Shopify cache issues can prevent updates from appearing immediately. Clear your browser and Shopify cache.
+
+## 6. Contact Support
+- If all else fails, reach out to Tolstoy support for further assistance by clicking the 'Talk to support' button.
+
+This article aims to help users independently resolve issues with videos not displaying in Shopify collections, ensuring a smoother integration and usage of Tolstoy videos in their e-commerce platform.


### PR DESCRIPTION
Create a new article addressing the common issue of videos not reflecting in Shopify collections, including detailed troubleshooting steps and integration tips. This fills a critical gap in the knowledge base, as evidenced by user inquiries and support interactions.