### PR TITLE
PR: Created article: Maximum URLs for Widget Rules on Shopify PDPs

### DIFF
--- a/topics/knowledge-manager-articles/maximum-urls-for-widget-rules-on-shopify-pdps.md
+++ b/topics/knowledge-manager-articles/maximum-urls-for-widget-rules-on-shopify-pdps.md
@@ -1,0 +1,13 @@
+# Maximum URLs for Widget Rules on Shopify Product Detail Pages (PDPs)
+
+When configuring widget rules for displaying content on Shopify Product Detail Pages (PDPs), it's important to understand the limitations regarding the number of URLs that can be included.
+
+## Overview
+- There is no hard limit on the number of URLs you can specify for widget rules. However, for optimal performance and manageability, it is recommended to keep the list concise and well-organized.
+
+## Best Practices
+- Group similar product pages under a single rule when possible.
+- Use URL patterns to cover multiple PDPs, reducing the need for individual URL entries.
+- Regularly review and update your URL lists to ensure they remain relevant and efficient.
+
+By following these guidelines, you can effectively manage the URLs for your widgets on Shopify PDPs, ensuring a smooth and targeted user experience.


### PR DESCRIPTION
Create a new article to address the specific query about the maximum number of URLs that can be added for widget rules on Shopify PDPs. This article will help clarify common misconceptions and provide best practices for managing URL rules efficiently.