### PR TITLE
PR: Created article: Adding 10 Assets to Homepage Spotlight Carousel

### DIFF
--- a/topics/knowledge-manager-articles/adding-10-assets-to-homepage-spotlight-carousel.md
+++ b/topics/knowledge-manager-articles/adding-10-assets-to-homepage-spotlight-carousel.md
@@ -1,0 +1,20 @@
+# Adding 10 Assets to Homepage Spotlight Carousel
+
+This article provides detailed instructions on how to add up to 10 assets to the Homepage Spotlight Carousel on Shopify using Tolstoy.
+
+## Step-by-Step Instructions
+1. Go to the Onsite tab in your Tolstoy Dashboard.
+2. Click 'Create Tolstoy'.
+3. Select 'Homepage spotlight'.
+4. Click 'Start creating'.
+5. In the Videos tab, select the videos you want to include, ensuring they are tagged with products if using the 'Product tagged' condition.
+
+## Supported Formats
+- Ensure all assets are in supported video formats (e.g., MP4, AVI).
+
+## Common Issues and Troubleshooting
+- If you cannot add more than a certain number of videos, check if there is a setting or limit within the carousel type.
+- Refresh your browser or try a different one to see if it might be a browser-related issue.
+- Check for any specific error messages that might provide more insight into what's going wrong.
+
+For further assistance, reach out to our support team by clicking the 'Talk to support' button in your dashboard.


### PR DESCRIPTION
Create a new article to address the specific issue of adding up to 10 assets to the Homepage Spotlight Carousel, which was a gap in our current knowledge base and led to user confusion and support intervention.