### PR TITLE
PR: Created article: Unlocking Videos in Tolstoy for Pro Plan Users on Shopify

### DIFF
--- a/topics/knowledge-manager-articles/unlocking-videos-in-tolstoy-for-pro-plan-users-on-shopify.md
+++ b/topics/knowledge-manager-articles/unlocking-videos-in-tolstoy-for-pro-plan-users-on-shopify.md
@@ -1,0 +1,17 @@
+# Unlocking Videos in Tolstoy for Pro Plan Users on Shopify
+
+This article provides a step-by-step guide on how to unlock videos in Tolstoy, specifically for users on the Pro plan using Shopify. Unlocking videos involves removing restrictions and accessing advanced features.
+
+## Step 1: Ensure Proper Tagging
+- Verify that your video is tagged with relevant products. This is crucial for unlocking advanced features like direct product links.
+
+## Step 2: Publishing Your Video
+- Make sure your video is published. For Shopify users, videos can be published directly on product pages or through the Shop app.
+
+## Step 3: Syncing Changes
+- If any changes are made, such as tagging new products or updating settings, sync your videos in the Tolstoy dashboard to reflect these changes in your Shopify store.
+
+## Step 4: Removing Restrictions
+- If your video has any restrictions like password protection, ensure these are correctly configured or removed as per your needs.
+
+By following these steps, you can effectively unlock your videos on the Pro plan using Shopify, enhancing your content's visibility and functionality.


### PR DESCRIPTION
Create a new article detailing the process of unlocking videos in Tolstoy for users on the Pro plan using Shopify. This addresses the knowledge gap identified in the conversation where the user was unclear on how to unlock videos, specifically focusing on removing restrictions and accessing advanced features.