### PR TITLE
PR: Created article: Customizing Currency Display in Shoppable Video Card

### DIFF
--- a/topics/knowledge-manager-articles/customizing-currency-display-in-shoppable-video-card.md
+++ b/topics/knowledge-manager-articles/customizing-currency-display-in-shoppable-video-card.md
@@ -1,0 +1,19 @@
+# Customizing Currency Display in Shoppable Video Card
+
+When using Shoppable video cards, the currency display is set by default based on your Shopify store settings, including the country code. This article guides you through checking your current settings and explores possible solutions for customizing this display.
+
+## Checking Current Currency Settings
+1. Log in to your Shopify store dashboard.
+2. Navigate to 'Settings' > 'General' > 'Store details'.
+3. Review the currency settings to understand how they are applied to your Shoppable video cards.
+
+## Customizing Currency Display
+Currently, the ability to remove or customize the country code directly in the Shoppable video card is limited. For specific customizations:
+- Contact support for advanced customization options.
+- Consider using custom CSS or JavaScript solutions as a workaround.
+
+## Limitations
+- Direct customization of the currency display, including removal of the country code, may not be supported directly through standard settings.
+- Changes might affect how prices are displayed across your entire e-commerce platform.
+
+For further assistance, please contact our support team.


### PR DESCRIPTION
Create a new article to address the customization or removal of the country code from the currency display in Shoppable video cards, providing users with guidance on checking current settings and exploring possible solutions.