### PR TITLE
PR: Created article: Rounding Corners of Videos in Tolstoy

### DIFF
--- a/topics/knowledge-manager-articles/rounding-corners-of-videos-in-tolstoy.md
+++ b/topics/knowledge-manager-articles/rounding-corners-of-videos-in-tolstoy.md
@@ -1,0 +1,17 @@
+# Rounding Corners of Videos in Tolstoy
+
+Currently, Tolstoy does not support the direct feature to round the corners of videos within the platform. However, you can achieve this effect by using third-party video editing software before uploading your videos to Tolstoy. Here are some recommended tools and steps to round the corners of your videos:
+
+## Recommended Video Editing Tools
+- **Adobe Premiere Pro**: Offers comprehensive video editing features including the ability to apply masks and effects to video corners.
+- **Final Cut Pro**: Similar to Premiere Pro, it provides extensive editing capabilities and effects for customizing video shapes.
+- **Camtasia**: A simpler tool for beginners that also includes options for video shaping and effects.
+
+## Steps to Round Corners
+1. Open your video in the chosen editing software.
+2. Locate the effects or mask panel.
+3. Apply a mask or effect that rounds the corners of the video frame.
+4. Adjust the radius of the corners as per your preference.
+5. Export the video in a supported format for Tolstoy.
+
+By following these steps, you can customize the appearance of your videos to include rounded corners before uploading them to your Tolstoy account.


### PR DESCRIPTION
Create a new article explaining how to round the corners of videos using third-party tools before uploading to Tolstoy, as this feature is not natively supported by the platform. This addresses a gap in the knowledge base and provides users with clear instructions on achieving this effect externally.