### PR TITLE
PR: Created article: Disabling the Tolstoy Cart on Shopify

### DIFF
--- a/topics/knowledge-manager-articles/disabling-the-tolstoy-cart-on-shopify.md
+++ b/topics/knowledge-manager-articles/disabling-the-tolstoy-cart-on-shopify.md
@@ -1,0 +1,16 @@
+# Disabling the Tolstoy Cart on Shopify
+
+This guide provides detailed instructions on how to disable the Tolstoy cart for users operating on the Shopify platform. Disabling the cart can be necessary for various operational or strategic reasons. Follow these steps to access and adjust the settings either through the Shopify admin panel or directly in the Tolstoy app settings.
+
+## Accessing the Shopify Admin Panel
+1. Log in to your Shopify admin panel.
+2. Navigate to the 'Apps' section and select the Tolstoy app.
+
+## Adjusting Settings in the Tolstoy App
+1. Within the Tolstoy app settings, locate the 'Cart Settings' or similar section.
+2. Find the option to disable the cart and toggle it off.
+
+## Confirm Changes
+Ensure that the changes are saved and confirm that the cart is disabled by checking the cart functionality on your storefront.
+
+By following these steps, you can successfully disable the Tolstoy cart on your Shopify store, allowing for greater customization of your e-commerce environment.


### PR DESCRIPTION
Create a new article providing a comprehensive guide on how to disable the Tolstoy cart, specifically tailored for users on Shopify. This fills a gap in the knowledge base by offering clear, step-by-step instructions for accessing and adjusting settings in the Shopify admin panel or the Tolstoy app settings.